### PR TITLE
 Code and tests compile again, memory-freeing problems solved, RNG class used by OptAlg

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,9 +15,13 @@ bindir	 = @bindir@
 srcdir         = @srcdir@
 VPATH          = @srcdir@
 
-all clean install uninstall lib phase_estimation:
+all install uninstall lib phase_estimation:
 	$(MAKE) -C src $@
 
+clean:
+	$(MAKE) -C src $@
+	$(MAKE) -C tests $@
+		
 test:
 	$(MAKE) -C tests $@
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -34,40 +34,33 @@ CUDA_LDFLAGS   = @CUDA_LDFLAGS@
 NVCC       	   = @NVCC@
 
 # VPATH-related substitution variables
-srcdir	 = @srcdir@
-VPATH	  = @srcdir@
+srcdir	 = ./../src
 
-OBJS=main.o candidate.o phase_loss_opt.o io.o problem.o mpi_optalg.o mpi_pso.o mpi_de.o rng.o
+MAINOBJS=$(srcdir)/candidate.o $(srcdir)/phase_loss_opt.o $(srcdir)/io.o $(srcdir)/problem.o $(srcdir)/mpi_optalg.o $(srcdir)/mpi_pso.o $(srcdir)/mpi_de.o $(srcdir)/rng.o
 
 ifdef CUDA_LIBS
-	OBJS+=rng_gpu.cu.co
+	MAINOBJS+=rng_gpu.cu.co
 else 
   ifdef VSL_LIBS
-		OBJS+=rng_vsl.o
+		MAINOBJS+=rng_vsl.o
 	endif
 endif
+TEST_OBJS=$(MAINOBJS) unittests.o
 
-all: phase_estimation
-	
-phase_estimation: $(OBJS)
-	$(CXX) $(DEFS) $(CXXFLAGS) $(MPI_LIBDIR) $(VSL_LIBDIR) $(CUDA_LDFLAGS) -o $@ $^ $(LIBS) $(MPI_LIBS) $(VSL_LIBS) $(CUDA_LIBS)
+test check: $(TEST_OBJS)
+	$(CXX) $(DEFS) $(CXXFLAGS) -g $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -o unittest $^ $(LIBS) $(CUDA_LIBS) ${MPI_LIBS} $(TEST_LIBS) -lunittest++
 
 %.o: %.cpp
-		$(CXX) $(DEFS) $(CXXFLAGS) $(MPI_INC) $(CUDA_INC) $(VSL_INC) -I$(srcdir) -I.. -o $@ -c $(srcdir)/$<
+	$(CXX) $(DEFS) $(CXXFLAGS) -g $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -I$(srcdir) -o $@ -c $^ 
 
-%.cu.co: %.cu
-		$(NVCC) $(DEFS) $(MPI_INC) $(CUDA_INC) $(CUDA_CFLAGS) -I$(srcdir) -I.. -o $@ -c $(srcdir)/$<
+$(srcdir)/%.o: $(srcdir)/%.cpp
+	$(MAKE) -C $(srcdir) $@
 
+$(srcdir)/%.cu.co: $(srcdir)/%.cu
+	$(MAKE) -C $(srcdir) $@
+	
 clean:
-	-rm -f phase_estimation $(OBJS) 1>/dev/null
-
-install:
-	$(INSTALL) -d $(DESTDIR)$(bindir)
-	$(INSTALL_PROGRAM) -m 0755 phase_estimation \
-	 $(DESTDIR)$(bindir)
-	 
-uninstall:
-	-rm $(DESTDIR)$(bindir)/phase_estimation &>/dev/null
+	-rm -f $(TEST_OBJS) unittest $(OBJS) 1>/dev/null
 
 Makefile: Makefile.in ../config.status
 	cd .. && ./config.status $@
@@ -75,4 +68,4 @@ Makefile: Makefile.in ../config.status
 ../config.status: ../configure
 	cd .. && ./config.status --recheck
 
-.PHONY: all clean install uninstall
+.PHONY: all clean

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -37,7 +37,7 @@ NVCC       	   = @NVCC@
 srcdir	 = @srcdir@
 VPATH	  = @srcdir@
 
-OBJS=main.o phase_loss_opt.o io.o problem.o mpi_optalg.o mpi_pso.o mpi_de.o rng.o
+OBJS=main.o candidate.o phase_loss_opt.o io.o problem.o mpi_optalg.o mpi_pso.o mpi_de.o rng.o
 
 ifdef CUDA_LIBS
 	OBJS+=rng_gpu.cu.co

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -34,33 +34,40 @@ CUDA_LDFLAGS   = @CUDA_LDFLAGS@
 NVCC       	   = @NVCC@
 
 # VPATH-related substitution variables
-srcdir	 = ./../src
+srcdir	 = @srcdir@
+VPATH	  = @srcdir@
 
-MAINOBJS=$(srcdir)/candidate.o $(srcdir)/phase_loss_opt.o $(srcdir)/io.o $(srcdir)/problem.o $(srcdir)/mpi_optalg.o $(srcdir)/mpi_pso.o $(srcdir)/mpi_de.o $(srcdir)/rng.o
+OBJS=main.o candidate.o phase_loss_opt.o io.o problem.o mpi_optalg.o mpi_pso.o mpi_de.o rng.o
 
 ifdef CUDA_LIBS
-	MAINOBJS+=rng_gpu.cu.co
+	OBJS+=rng_gpu.cu.co
 else 
   ifdef VSL_LIBS
-		MAINOBJS+=rng_vsl.o
+		OBJS+=rng_vsl.o
 	endif
 endif
-TEST_OBJS=$(MAINOBJS) unittests.o
 
-test check: $(TEST_OBJS)
-	$(CXX) $(DEFS) $(CXXFLAGS) -g $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -o unittest $^ $(LIBS) $(CUDA_LIBS) ${MPI_LIBS} $(TEST_LIBS) -lunittest++
+all: phase_estimation
+	
+phase_estimation: $(OBJS)
+	$(CXX) $(DEFS) $(CXXFLAGS) $(MPI_LIBDIR) $(VSL_LIBDIR) $(CUDA_LDFLAGS) -o $@ $^ $(LIBS) $(MPI_LIBS) $(VSL_LIBS) $(CUDA_LIBS)
 
 %.o: %.cpp
-	$(CXX) $(DEFS) $(CXXFLAGS) -g $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -I$(srcdir) -o $@ -c $^ 
+		$(CXX) $(DEFS) $(CXXFLAGS) $(MPI_INC) $(CUDA_INC) $(VSL_INC) -I$(srcdir) -I.. -o $@ -c $(srcdir)/$<
 
-$(srcdir)/%.o: $(srcdir)/%.cpp
-	$(MAKE) -C $(srcdir) $@
+%.cu.co: %.cu
+		$(NVCC) $(DEFS) $(MPI_INC) $(CUDA_INC) $(CUDA_CFLAGS) -I$(srcdir) -I.. -o $@ -c $(srcdir)/$<
 
-$(srcdir)/%.cu.co: $(srcdir)/%.cu
-	$(MAKE) -C $(srcdir) $@
-	
 clean:
-	-rm -f $(TEST_OBJS) unittest $(OBJS) 1>/dev/null
+	-rm -f phase_estimation $(OBJS) 1>/dev/null
+
+install:
+	$(INSTALL) -d $(DESTDIR)$(bindir)
+	$(INSTALL_PROGRAM) -m 0755 phase_estimation \
+	 $(DESTDIR)$(bindir)
+	 
+uninstall:
+	-rm $(DESTDIR)$(bindir)/phase_estimation &>/dev/null
 
 Makefile: Makefile.in ../config.status
 	cd .. && ./config.status $@
@@ -68,4 +75,4 @@ Makefile: Makefile.in ../config.status
 ../config.status: ../configure
 	cd .. && ./config.status --recheck
 
-.PHONY: all clean
+.PHONY: all clean install uninstall

--- a/src/candidate.cpp
+++ b/src/candidate.cpp
@@ -1,16 +1,20 @@
 #include "candidate.h"
 
 Candidate::~Candidate() {
-    //delete[] must be commented out for unit testing in order for the framework to operate properly.
-    delete[] can_best;
-    delete[] contender;
-    delete[] velocity;
-    delete[] global_best;
-
-    delete[] best_fit;
-    delete[] cont_fit;
-    delete[] global_fit;
+    if (is_candidate_initialized) {
+        delete[] can_best;
+        delete[] contender;
+        delete[] global_best;
+       
+        delete[] best_fit;
+        delete[] cont_fit;
+        delete[] global_fit;
     }
+  
+    if (is_velocity_initialized) {
+        delete[] velocity;
+    }
+}
 
 void Candidate::init_can(int numvar, int fit_size) {
     if(numvar <= 0) {
@@ -28,10 +32,12 @@ void Candidate::init_can(int numvar, int fit_size) {
     best_fit = new double[num_fit];
     cont_fit = new double[num_fit];
     global_fit = new double[num_fit];
-    }
+    is_candidate_initialized = true;
+}
 
 void Candidate::init_velocity() { //This function can only be called after init_can. What can we do make sure it is safe to use?
     velocity = new double[num];
+    is_velocity_initialized = true;
     }
 
 void Candidate::update_cont(double *input) {

--- a/src/candidate.h
+++ b/src/candidate.h
@@ -10,7 +10,7 @@ class Candidate {
         friend class OptAlg;
 
     public:
-        Candidate() {};
+        Candidate() {is_velocity_initialized = false; is_candidate_initialized = false;};
         ~Candidate();
 
         void init_can(int numvar, int fit_size);
@@ -50,6 +50,7 @@ class Candidate {
         int num, num_fit;
         double *best_fit, *cont_fit, *global_fit;
         int times, best_times, global_times;//number of samples used to calculate average best_fit
+        bool is_velocity_initialized, is_candidate_initialized;        
 
         //memory arrays
         double *can_best;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,9 +96,9 @@ int main(int argc, char **argv) {
             }
         OptAlg* opt;
         if (optimization == "de") {
-             opt = new DE(problem);
+             opt = new DE(problem, gaussian_rng);
         } else if (optimization == "pso") {
-             opt = new PSO(problem);
+             opt = new PSO(problem, gaussian_rng);
         } else {
              throw runtime_error("Unknown optimization algorithm");
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
 
     /*parameter settings*/
     int pop_size, N_begin, N_cut, N_end, iter, iter_begin, repeat, seed;
-    string output_filename, time_filename;
+    string output_filename, time_filename, optimization;
     char const *config_filename;
     if (argc > 1) {
         config_filename = argv[1];
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
         }
     read_config_file(config_filename, &pop_size, &N_begin, &N_cut, &N_end, &iter,
                      &iter_begin, &repeat, &seed, &output_filename,
-                     &time_filename);
+                     &time_filename, &optimization);
 
     double prev_dev = 0.01 * M_PI;
     double new_dev = 0.25 * M_PI;
@@ -94,7 +94,14 @@ int main(int argc, char **argv) {
             numvar = 4;
             problem = new Phase(numvar, gaussian_rng, uniform_rng);
             }
-        OptAlg* opt = new DE(problem);
+        OptAlg* opt;
+        if (optimization == "de") {
+             opt = new DE(problem);
+        } else if (optimization == "pso") {
+             opt = new PSO(problem);
+        } else {
+             throw runtime_error("Unknown optimization algorithm");
+        }
 
         fitarray = new double[problem->num_fit];
 

--- a/src/mpi_optalg.cpp
+++ b/src/mpi_optalg.cpp
@@ -42,7 +42,7 @@ void OptAlg::Init_previous(double prev_dev, double new_dev, int psize, double *p
     for(int p = 0; p < pop_size; ++p) {
         //generate candidate
         for(int i = 0; i < num; ++i) {
-            input[i] = fabs(rand_Gaussian(prev_soln[i], dev[i]));
+            input[i] = fabs(gaussian_rng->next_rand(prev_soln[i], dev[i]));
             }
         prob->boundary(input);
         //store it in candidate object
@@ -311,12 +311,6 @@ bool OptAlg::check_success(int t, int D, double fit, double slope, double interc
         }
     }
 
-
-/*##############################Auxiliiary functions##############################*/
-double OptAlg::rand_Gaussian(double mean, double dev) {
-    //Approximating the Gaussian distribution with uniform distribution
-    return (double(rand()) / RAND_MAX - 0.5) * 2 * dev + mean;
-    }/*end of rand_Gaussian*/
 
 void OptAlg::dev_gen(double *dev_array, double prev_dev, double new_dev, int cut_off) {
     for(int i = 0; i < num; ++i) {

--- a/src/mpi_optalg.h
+++ b/src/mpi_optalg.h
@@ -7,11 +7,12 @@
 
 #include "problem.h"
 #include "candidate.h"
+#include "rng.h"
 
 class OptAlg {
     public:
         OptAlg() {};
-        OptAlg(Problem *problem_ptr) {
+        OptAlg(Problem *problem_ptr, Rng *gaussian_rng): gaussian_rng(gaussian_rng) {
             prob = problem_ptr;
             num = prob->num;
             num_fit = prob->num_fit;
@@ -40,7 +41,6 @@ class OptAlg {
         void set_success(int iter, bool goal);
         bool check_success(int t, int D, double fit, double slope, double intercept);
 
-        double rand_Gaussian(double mean, double dev);
         void dev_gen(double *dev_array, double prev_dev, double new_dev, int cut_off);
 
         //Selecting solution
@@ -64,6 +64,7 @@ class OptAlg {
         int num, num_fit;
 
     protected:
+        Rng *gaussian_rng;
         int pop_size, T, t;
         Candidate *pop;
         bool goal;
@@ -72,11 +73,7 @@ class OptAlg {
 class DE : public OptAlg {
     public:
         DE() {};
-        DE(Problem *problem_ptr): F(0.1), Cr(0.6) {
-            this->prob = problem_ptr;
-            this->num = this->prob->num;
-            this->num_fit = prob->num_fit;
-            }
+        DE(Problem *problem_ptr, Rng *gaussian_rng): OptAlg(problem_ptr, gaussian_rng), F(0.1), Cr(0.6) {};
         ~DE() {};
 
         void put_to_best(int my_rank, int total_pop, int nb_proc);
@@ -97,11 +94,7 @@ class DE : public OptAlg {
 class PSO : public OptAlg {
     public:
         PSO() {};
-        PSO(Problem *problem_ptr): w(0.8), phi1(0.6), phi2(1.0), v_max(0.2) {
-            this->prob = problem_ptr;
-            this->num = this->prob->num;
-            this->num_fit = prob->num_fit;
-            }
+        PSO(Problem *problem_ptr, Rng *gaussian_rng): OptAlg(problem_ptr, gaussian_rng), w(0.8), phi1(0.6), phi2(1.0), v_max(0.2) {};
         ~PSO() {};
 
         void put_to_best(int my_rank, int total_pop, int nb_proc);

--- a/src/mpi_optalg.h
+++ b/src/mpi_optalg.h
@@ -65,7 +65,7 @@ class OptAlg {
 
     protected:
         int pop_size, T, t;
-        Candidate<double> *pop;
+        Candidate *pop;
         bool goal;
     };
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -48,10 +48,10 @@ endif
 TEST_OBJS=$(MAINOBJS) unittests.o
 
 test check: $(TEST_OBJS)
-	$(CXX) $(DEFS) $(CXXFLAGS) $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -o unittest $^ $(LIBS) $(CUDA_LIBS) ${MPI_LIBS} $(TEST_LIBS) -lunittest++
+	$(CXX) $(DEFS) $(CXXFLAGS) -g $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -o unittest $^ $(LIBS) $(CUDA_LIBS) ${MPI_LIBS} $(TEST_LIBS) -lunittest++
 
 %.o: %.cpp
-	$(CXX) $(DEFS) $(CXXFLAGS) $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -I$(srcdir) -o $@ -c $^ 
+	$(CXX) $(DEFS) $(CXXFLAGS) -g $(CUDA_LDFLAGS) ${MPI_LIBDIR} -I.. -I$(srcdir) -o $@ -c $^ 
 
 $(srcdir)/%.o: $(srcdir)/%.cpp
 	$(MAKE) -C $(srcdir) $@
@@ -60,7 +60,7 @@ $(srcdir)/%.cu.co: $(srcdir)/%.cu
 	$(MAKE) -C $(srcdir) $@
 	
 clean:
-	-rm -f $(OBJS) 1>/dev/null
+	-rm -f $(TEST_OBJS) unittest $(OBJS) 1>/dev/null
 
 Makefile: Makefile.in ../config.status
 	cd .. && ./config.status $@

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -36,7 +36,7 @@ NVCC       	   = @NVCC@
 # VPATH-related substitution variables
 srcdir	 = ./../src
 
-MAINOBJS=$(srcdir)/phase_loss_opt.o $(srcdir)/io.o $(srcdir)/problem.o $(srcdir)/mpi_optalg.o $(srcdir)/mpi_pso.o $(srcdir)/mpi_de.o $(srcdir)/rng.o
+MAINOBJS=$(srcdir)/candidate.o $(srcdir)/phase_loss_opt.o $(srcdir)/io.o $(srcdir)/problem.o $(srcdir)/mpi_optalg.o $(srcdir)/mpi_pso.o $(srcdir)/mpi_de.o $(srcdir)/rng.o
 
 ifdef CUDA_LIBS
 	MAINOBJS+=rng_gpu.cu.co

--- a/tests/unittests.cpp
+++ b/tests/unittests.cpp
@@ -26,20 +26,22 @@ SUITE(phase_mainfunc) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = -5;
         bool err = 0;
         Problem* problem;
-        CHECK_THROW(problem = new Phase(numvar, rng), invalid_argument);
+        CHECK_THROW(problem = new Phase(numvar, gaussian_rng, uniform_rng), invalid_argument);
         }
     TEST(boundary) {
         int xn = 10;
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 10;
-        Phase* problem = new Phase(numvar, rng);
+        Phase* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         double Phi = 4 * M_PI / (numvar + 1);
         double array[numvar];
         bool err = 0;
@@ -65,9 +67,10 @@ SUITE(phase_mainfunc) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 10;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         double can[numvar + 1];
         int K = numvar * numvar * 10;
         double fit[problem->num_fit];
@@ -80,18 +83,18 @@ SUITE(phase_mainfunc) {
         }
 
     }
-//from candidate.h
+//from candidate
 SUITE(candidate_initialize_memory) {
     TEST(numvar_invalid) {
         int numvar = -5;
         int num_fit = 2;
-        Candidate<double> can1;
+        Candidate can1;
         CHECK_THROW(can1.init_can(numvar, num_fit), out_of_range);
         }
     TEST(numfit_invalid) {
         int numvar = 4;
         int num_fit = -2;
-        Candidate<double> can1;
+        Candidate can1;
         CHECK_THROW(can1.init_can(numvar, num_fit), invalid_argument);
         }
     }
@@ -99,7 +102,7 @@ SUITE(candidate_reads) {
     TEST(read_vel) {
         int numvar = 4;
         int num_fit = 2;
-        Candidate<double> can1;
+        Candidate can1;
         can1.init_can(numvar, num_fit);
         can1.init_velocity();
         double input[numvar];
@@ -118,7 +121,7 @@ SUITE(candidate_reads) {
     TEST(read_best) {
         int numvar = 4;
         int num_fit = 2;
-        Candidate<double> can1;
+        Candidate can1;
         can1.init_can(numvar, num_fit);
         double input[numvar];
         double output[numvar];
@@ -144,9 +147,10 @@ SUITE(Init_pop) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 10;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         int pop_size = -5;
@@ -157,9 +161,10 @@ SUITE(Init_pop) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 5;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double prev_dev = 0.1;
@@ -179,9 +184,10 @@ SUITE(success_criteria) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         int iter = 0;
@@ -193,9 +199,10 @@ SUITE(success_criteria) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         int iter = 10;
@@ -214,9 +221,10 @@ SUITE(success_criteria) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         int iter = 10;
@@ -238,9 +246,10 @@ SUITE(alg_aux_functions) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         int dev_cut_off = numvar - 1;
@@ -258,9 +267,10 @@ SUITE(policy_criteria) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double error = 4.0;
@@ -274,9 +284,10 @@ SUITE(policy_criteria) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double error = 4.0;
@@ -290,9 +301,10 @@ SUITE(policy_criteria) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double error = 2.5;
@@ -310,9 +322,10 @@ SUITE(Linear_Regression) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double input = 0.975;
@@ -325,9 +338,10 @@ SUITE(Linear_Regression) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double slope, intercept, mean_x;
@@ -347,9 +361,10 @@ SUITE(Linear_Regression) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double slope, intercept, mean_x;
@@ -369,9 +384,10 @@ SUITE(Linear_Regression) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double slope, intercept, mean_x, SSres;
@@ -393,9 +409,10 @@ SUITE(Linear_Regression) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double slope, intercept, mean_x, SSres;
@@ -417,9 +434,10 @@ SUITE(Linear_Regression) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double slope, intercept, mean_x, SSres;
@@ -443,9 +461,10 @@ SUITE(Linear_Regression) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double slope, intercept, mean_x, SSres;
@@ -470,9 +489,10 @@ SUITE(Selections) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new OptAlg(problem);
 
         double fit[numvar];
@@ -494,9 +514,10 @@ SUITE(de_constructor) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
         CHECK(alg->num == numvar);
         }
@@ -507,9 +528,10 @@ SUITE(de_functions) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
 
         double out_param[2];
@@ -521,9 +543,10 @@ SUITE(de_functions) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
 
         double in_param[2] = {1.3, 2.1};
@@ -540,16 +563,17 @@ SUITE(check_catch) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = -10;
         try {
-            Problem* problem = new Phase(numvar, rng);
+            Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
             OptAlg* alg = new DE(problem);
             }
         catch(invalid_argument) {
             numvar = 4;
             }
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
         CHECK(alg->num == 4);
         }
@@ -558,9 +582,10 @@ SUITE(check_catch) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
 
         double p = 1.0;
@@ -573,9 +598,10 @@ SUITE(check_catch) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
 
         double error = 0.1;
@@ -595,9 +621,10 @@ SUITE(check_catch) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
 
         int data_size = 0;
@@ -617,9 +644,10 @@ SUITE(check_catch) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
 
         int data_size = 0;
@@ -639,9 +667,10 @@ SUITE(check_catch) {
         int xu = 10;
         int seed = 0;
         int rank = 0;
-        Rng *rng = new Rng(xn, xu, seed, rank);
+        Rng *gaussian_rng = new Rng(true, xn, seed, rank);
+        Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
-        Problem* problem = new Phase(numvar, rng);
+        Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
         OptAlg* alg = new DE(problem);
 
         int data_size = -10;

--- a/tests/unittests.cpp
+++ b/tests/unittests.cpp
@@ -151,7 +151,7 @@ SUITE(Init_pop) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 10;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         int pop_size = -5;
         CHECK_THROW(alg->Init_population(pop_size), invalid_argument);
@@ -165,7 +165,7 @@ SUITE(Init_pop) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 5;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double prev_dev = 0.1;
         double new_dev = 0.5;
@@ -188,7 +188,7 @@ SUITE(success_criteria) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         int iter = 0;
         double goal_in = 0.1;
@@ -203,7 +203,7 @@ SUITE(success_criteria) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         int iter = 10;
         double goal_in = 0.1;
@@ -225,7 +225,7 @@ SUITE(success_criteria) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         int iter = 10;
         double goal_in = 0.1;
@@ -250,7 +250,7 @@ SUITE(alg_aux_functions) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         int dev_cut_off = numvar - 1;
         double dev[numvar];
@@ -271,7 +271,7 @@ SUITE(policy_criteria) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double error = 4.0;
         double sharp = 1.0;
@@ -288,7 +288,7 @@ SUITE(policy_criteria) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double error = 4.0;
         double sharp = 0.9;
@@ -305,7 +305,7 @@ SUITE(policy_criteria) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double error = 2.5;
         double sharp = 0.9;
@@ -326,7 +326,7 @@ SUITE(Linear_Regression) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double input = 0.975;
         double result;
@@ -342,7 +342,7 @@ SUITE(Linear_Regression) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double slope, intercept, mean_x;
         double x[numvar];
@@ -365,7 +365,7 @@ SUITE(Linear_Regression) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double slope, intercept, mean_x;
         double x[numvar];
@@ -388,7 +388,7 @@ SUITE(Linear_Regression) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double slope, intercept, mean_x, SSres;
         double interval;
@@ -413,7 +413,7 @@ SUITE(Linear_Regression) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double slope, intercept, mean_x, SSres;
         double interval;
@@ -438,7 +438,7 @@ SUITE(Linear_Regression) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double slope, intercept, mean_x, SSres;
         double interval;
@@ -465,7 +465,7 @@ SUITE(Linear_Regression) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double slope, intercept, mean_x, SSres;
         double interval;
@@ -493,7 +493,7 @@ SUITE(Selections) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new OptAlg(problem);
+        OptAlg* alg = new OptAlg(problem, gaussian_rng);
 
         double fit[numvar];
         int indx;
@@ -518,7 +518,7 @@ SUITE(de_constructor) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
         CHECK(alg->num == numvar);
         }
     }
@@ -532,7 +532,7 @@ SUITE(de_functions) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
 
         double out_param[2];
         alg->read_param(out_param);
@@ -547,7 +547,7 @@ SUITE(de_functions) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 8;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
 
         double in_param[2] = {1.3, 2.1};
         double out_param[2];
@@ -568,13 +568,13 @@ SUITE(check_catch) {
         int numvar = -10;
         try {
             Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-            OptAlg* alg = new DE(problem);
+            OptAlg* alg = new DE(problem, gaussian_rng);
             }
         catch(invalid_argument) {
             numvar = 4;
             }
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
         CHECK(alg->num == 4);
         }
     TEST(catch_quantile) {
@@ -586,7 +586,7 @@ SUITE(check_catch) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
 
         double p = 1.0;
         double result = 0;
@@ -602,7 +602,7 @@ SUITE(check_catch) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
 
         double error = 0.1;
         double sharp = 1.0;
@@ -625,7 +625,7 @@ SUITE(check_catch) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
 
         int data_size = 0;
         double x[numvar];
@@ -648,7 +648,7 @@ SUITE(check_catch) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
 
         int data_size = 0;
         double x[numvar];
@@ -671,7 +671,7 @@ SUITE(check_catch) {
         Rng *uniform_rng = new Rng(false, xu, seed, rank);
         int numvar = 4;
         Problem* problem = new Phase(numvar, gaussian_rng, uniform_rng);
-        OptAlg* alg = new DE(problem);
+        OptAlg* alg = new DE(problem, gaussian_rng);
 
         int data_size = -10;
         double x[numvar];


### PR DESCRIPTION
There was a regression in calling read_config_file. Furthermore, the code and the tests did not compile with the new non-templated candidate class. The memory freeing problems in the candidate class are resolved.